### PR TITLE
use Store to get master_branch value in get_commit_list

### DIFF
--- a/src/core/CommitMetadata.ts
+++ b/src/core/CommitMetadata.ts
@@ -165,8 +165,9 @@ export async function range(commit_group_map?: CommitGroupMap) {
 }
 
 async function get_commit_list() {
+  const master_branch = Store.getState().master_branch;
   const log_result = await cli(
-    `git log master..HEAD --oneline --format=%H --color=never`
+    `git log ${master_branch}..HEAD --oneline --format=%H --color=never`
   );
 
   if (!log_result.stdout) {


### PR DESCRIPTION
## Problem

We want to try using `git-stack-cli`, but were running into issues using the branch override command. (We don't use `master` or `main` in our directory). I noticed that `get_commit_list` is still referencing `master` directly which was causing the error.

## Solution

Use the stored `master_branch` value in place of `master` within `get_commit_list`. 