### PR TITLE
Support PR template

### DIFF
--- a/src/app/Main.tsx
+++ b/src/app/Main.tsx
@@ -5,6 +5,7 @@ import { LocalMergeRebase } from "~/app/LocalMergeRebase";
 import { ManualRebase } from "~/app/ManualRebase";
 import { PostRebaseStatus } from "~/app/PostRebaseStatus";
 import { PreLocalMergeRebase } from "~/app/PreLocalMergeRebase";
+import { PreManualRebase } from "~/app/PreManualRebase";
 import { PreSelectCommitRanges } from "~/app/PreSelectCommitRanges";
 import { SelectCommitRanges } from "~/app/SelectCommitRanges";
 import { Status } from "~/app/Status";
@@ -35,6 +36,9 @@ export function Main() {
 
     case "select-commit-ranges":
       return <SelectCommitRanges />;
+
+    case "pre-manual-rebase":
+      return <PreManualRebase />;
 
     case "manual-rebase":
       return <ManualRebase />;

--- a/src/app/ManualRebase.tsx
+++ b/src/app/ManualRebase.tsx
@@ -46,6 +46,11 @@ async function run() {
   // always listen for SIGINT event and restore git state
   process.once("SIGINT", handle_exit);
 
+  let DEFAULT_PR_BODY = "";
+  if (state.pr_template_body) {
+    DEFAULT_PR_BODY = state.pr_template_body;
+  }
+
   const temp_branch_name = `${branch_name}_${short_id()}`;
 
   const commit_range = await CommitMetadata.range(commit_map);
@@ -328,7 +333,7 @@ async function run() {
         branch: group.id,
         base: group.base,
         title: group.title,
-        body: "",
+        body: DEFAULT_PR_BODY,
       });
 
       if (!pr_url) {
@@ -363,7 +368,7 @@ async function run() {
 
       invariant(group.base, "group.base must exist");
 
-      const body = group.pr?.body || "";
+      const body = group.pr?.body || DEFAULT_PR_BODY;
 
       const update_body = StackSummaryTable.write({
         body,

--- a/src/app/PreManualRebase.tsx
+++ b/src/app/PreManualRebase.tsx
@@ -1,0 +1,92 @@
+import * as React from "react";
+
+import fs from "node:fs";
+import path from "node:path";
+
+import * as Ink from "ink-cjs";
+
+import { Await } from "~/app/Await";
+import { Brackets } from "~/app/Brackets";
+import { FormatText } from "~/app/FormatText";
+import { Store } from "~/app/Store";
+import { colors } from "~/core/colors";
+import { invariant } from "~/core/invariant";
+
+export function PreManualRebase() {
+  return <Await fallback={null} function={run} />;
+}
+
+async function run() {
+  const state = Store.getState();
+  const actions = state.actions;
+  const repo_root = state.repo_root;
+  const argv = state.argv;
+
+  invariant(repo_root, "repo_root must exist");
+  invariant(argv, "argv must exist");
+
+  if (!argv.template) {
+    return actions.set((state) => {
+      state.step = "manual-rebase";
+    });
+  }
+
+  // ./.github/PULL_REQUEST_TEMPLATE/*.md
+  let pr_templates: Array<string> = [];
+  if (fs.existsSync(template_pr_template(repo_root))) {
+    pr_templates = fs.readdirSync(template_pr_template(repo_root));
+  }
+
+  // look for pull request template
+  // https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
+  // ./.github/pull_request_template.md
+  // ./pull_request_template.md
+  // ./docs/pull_request_template.md
+  let pr_template_body: null | string = null;
+  if (fs.existsSync(github_pr_template(repo_root))) {
+    pr_template_body = fs.readFileSync(github_pr_template(repo_root), "utf-8");
+  } else if (fs.existsSync(root_pr_template(repo_root))) {
+    pr_template_body = fs.readFileSync(root_pr_template(repo_root), "utf-8");
+  } else if (fs.existsSync(docs_pr_template(repo_root))) {
+    pr_template_body = fs.readFileSync(docs_pr_template(repo_root), "utf-8");
+  }
+
+  // check if repo has multiple pr templates
+  actions.set((state) => {
+    state.pr_template_body = pr_template_body;
+    state.pr_templates = pr_templates;
+
+    if (pr_templates.length > 0) {
+      actions.output(
+        <FormatText
+          wrapper={<Ink.Text color={colors.yellow} />}
+          message="{count} queryable templates found under {dir}, but not supported."
+          values={{
+            count: (
+              <Ink.Text color={colors.blue}>{pr_templates.length}</Ink.Text>
+            ),
+            dir: <Brackets>{template_pr_template("")}</Brackets>,
+          }}
+        />
+      );
+    }
+
+    state.step = "manual-rebase";
+  });
+}
+
+function github_pr_template(repo_root: string) {
+  return path.join(repo_root, ".github", "pull_request_template.md");
+}
+
+function root_pr_template(repo_root: string) {
+  return path.join(repo_root, "pull_request_template.md");
+}
+
+function docs_pr_template(repo_root: string) {
+  return path.join(repo_root, "docs", "pull_request_template.md");
+}
+
+function template_pr_template(repo_root: string) {
+  return path.join(repo_root, ".github", "PULL_REQUEST_TEMPLATE");
+}

--- a/src/app/SelectCommitRanges.tsx
+++ b/src/app/SelectCommitRanges.tsx
@@ -143,7 +143,7 @@ function SelectCommitRangesInternal(props: Props) {
 
         switch (inputLower) {
           case "s":
-            state.step = "manual-rebase";
+            state.step = "pre-manual-rebase";
             break;
         }
       });

--- a/src/app/Store.tsx
+++ b/src/app/Store.tsx
@@ -38,6 +38,8 @@ export type State = {
   branch_name: null | string;
   commit_range: null | CommitMetadata.CommitRange;
   commit_map: null | CommitMap;
+  pr_templates: Array<string>;
+  pr_template_body: null | string;
 
   step:
     | "github-api-error"
@@ -47,6 +49,7 @@ export type State = {
     | "local-merge-rebase"
     | "pre-select-commit-ranges"
     | "select-commit-ranges"
+    | "pre-manual-rebase"
     | "manual-rebase"
     | "post-rebase-status";
 
@@ -98,6 +101,8 @@ const BaseStore = createStore<State>()(
     branch_name: null,
     commit_range: null,
     commit_map: null,
+    pr_templates: [],
+    pr_template_body: null,
 
     step: "loading",
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -78,6 +78,13 @@ export async function command() {
         description: "Write state to local json file for debugging",
       })
 
+      .option("template", {
+        type: "boolean",
+        default: true,
+        description:
+          "Use automatic Github PR template, e.g. .github/pull_request_template.md, disable with --no-template",
+      })
+
       .option("mock-metadata", {
         hidden: true,
         type: "boolean",


### PR DESCRIPTION
- Looks for **`pull_request_template.md`** in the following locations (in-order), this **[matches Github behavior](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)**

> 1. **`./.github/pull_request_template.md`**
> 1. **`./pull_request_template.md`**
> 1. **`./docs/pull_request_template.md`**

- Applies the PR template, if found, when creating Github PRs in `manual-rebase` step
- New **`--template`** cli arg (defaults to `true`) to support **`--no-template`** which disables PR template entirely

> <img width="1037" alt="Screenshot 2024-07-27 at 9 34 24 PM" src="https://github.com/user-attachments/assets/f6272add-6584-4b72-ab2c-797d32998823">
