### PR TITLE
open all PRs as draft

### DIFF
--- a/src/app/ManualRebase.tsx
+++ b/src/app/ManualRebase.tsx
@@ -334,6 +334,7 @@ async function run() {
         base: group.base,
         title: group.title,
         body: DEFAULT_PR_BODY,
+        draft: argv.draft,
       });
 
       if (!pr_url) {

--- a/src/command.ts
+++ b/src/command.ts
@@ -71,6 +71,13 @@ export async function command() {
           'Set the master branch name, defaults to "master" (or "main" if "master" is not found)',
       })
 
+      .option("draft", {
+        type: "boolean",
+        alias: ["d"],
+        default: false,
+        description: "Open all PRs as drafts",
+      })
+
       .option("write-state-json", {
         hidden: true,
         type: "boolean",

--- a/src/core/github.tsx
+++ b/src/core/github.tsx
@@ -131,14 +131,18 @@ type CreatePullRequestArgs = {
   base: string;
   title: string;
   body: string;
+  draft: boolean;
 };
 
 export async function pr_create(args: CreatePullRequestArgs) {
   const title = safe_quote(args.title);
+  let command = `gh pr create --fill --head ${args.branch} --base ${args.base} --title="${title}" --body="${args.body}"`;
 
-  const cli_result = await cli(
-    `gh pr create --fill --head ${args.branch} --base ${args.base} --title="${title}" --body="${args.body}"`
-  );
+  if (args.draft) {
+    command += " --draft";
+  }
+
+  const cli_result = await cli(command);
 
   if (cli_result.code !== 0) {
     handle_error(cli_result.output);


### PR DESCRIPTION
# Description
Pass `-d or --draft` flag to `git stack` to open all PRs as draft. Default value is `false`

# Manual testing
`git stack -v`
![Screenshot 2024-07-28 at 11 41 42 AM](https://github.com/user-attachments/assets/e30e4d05-7f5d-4da9-8bac-c7a6e3d230a7)

Resulting PR
![Screenshot 2024-07-28 at 11 42 24 AM](https://github.com/user-attachments/assets/633a7f0b-131f-4049-b8c1-583065d0c55c)

`git stack help`

![Screenshot 2024-07-28 at 11 42 52 AM](https://github.com/user-attachments/assets/7b7fa91d-80f7-4183-be3d-76ef8003f17f)


#### [git stack](https://github.com/magus/git-stack-cli)
- 👉 `1` https://github.com/magus/git-stack-cli/pull/7