### PR TITLE
fix: do not read `.github/PULL_REQUEST_TEMPLATE` as file

### DIFF
--- a/src/app/PreManualRebase.tsx
+++ b/src/app/PreManualRebase.tsx
@@ -95,4 +95,4 @@ const PR_TEMPLATE = Object.freeze({
 });
 
 // prettier-ignore
-const PR_TEMPLATE_KEY_LIST = Object.keys(PR_TEMPLATE) as Array<keyof typeof PR_TEMPLATE>;
+const PR_TEMPLATE_KEY_LIST = ["Github", "Root", "Docs"] as Array<Exclude<keyof typeof PR_TEMPLATE, "TemplateDir">>;


### PR DESCRIPTION
## Summary

When `.github/PULL_REQUEST_TEMPLATE/*.md` existed, we attempted to read it as a file. Don't do that.

## Test Plan
Run fixed CLI and see it succeed.

```bash
pnpm run dev

# cd to git repository with .github/PULL_REQUEST_TEMPLATE/*.md
...

node ${GIT_STACK_CLI_DIR}/dist/js/index.js --verbose
```