### PR TITLE
fix: remove pr edit with no changes

### DIFF
--- a/src/app/SyncGithub.tsx
+++ b/src/app/SyncGithub.tsx
@@ -240,8 +240,6 @@ async function run() {
       if (!is_master_base(group)) {
         // ensure base matches pr in github
         await github.pr_edit({ branch: group.id, base: group.base });
-      } else {
-        await github.pr_edit({ branch: group.id });
       }
     } else {
       // create pr in github


### PR DESCRIPTION
### Description
In [newer versions of the gh cli](https://github.com/cli/cli/blob/6acf74e04e0e7642664f93cad96af4d72880c265/pkg/cmd/pr/edit/edit.go#L175), calling `gh pr edit` in non-interactive mode throws an error if no modification is passed.  This call does not seem to be necessary as the base branch is already set correctly in this else condition.  Alternatively, the call can be wrapped in explicit error handling in case it fails.

### Steps to Recreate
```bash
GH_PROMPT_DISABLED=1 gh pr edit 12 --repo magus/git-stack-cli
```

### Impact
When gh throws an error on this call, it breaks syncing of the PRs in the stack, stopping the PR body from being correctly updated with any new PRs/changes.

### Validation
I have cloned the repo locally and compiled a binary with the changes using bun.  With the updated binary I have confirmed that the error is no longer thrown and the body for the PRs in the stack is correctly updated as expected.