### PR TITLE
fix: remove requirement that remote urls end with .git suffix

### DIFF
--- a/src/app/GatherMetadata.tsx
+++ b/src/app/GatherMetadata.tsx
@@ -101,7 +101,7 @@ const RE = {
   // git@github.com:magus/git-multi-diff-playground.git
   // https://github.com/magus/git-multi-diff-playground.git
   // the .git suffix is optional for remote urls, and may not always be provided
-  repo_path: /(?<repo_path>[^:^/]+\/[^/]+)(?:.git)?$/,
+  repo_path: /(?<repo_path>[^:^/]+\/[^/]+)(?:\.git)?$/,
 };
 
 const BRANCH = {

--- a/src/app/GatherMetadata.tsx
+++ b/src/app/GatherMetadata.tsx
@@ -100,7 +100,8 @@ async function run() {
 const RE = {
   // git@github.com:magus/git-multi-diff-playground.git
   // https://github.com/magus/git-multi-diff-playground.git
-  repo_path: /(?<repo_path>[^:^/]+\/[^/]+)\.git/,
+  // the .git suffix is optional for remote urls, and may not always be provided
+  repo_path: /(?<repo_path>[^:^/]+\/[^/]+)(?:.git)?$/,
 };
 
 const BRANCH = {


### PR DESCRIPTION
### Description
In many git source control systems, the .git suffix is convention but not explicitly required.  Urls without this suffix should be properly handled without throwing an error.

### Steps to Recreate
```bash
git remote set-url origin https://github.com/magus/git-stack-cli
git stack
```

### Impact
Repositories that do not explicitly include the `.git` suffix will encounter an error with regex matching when trying to run `git stack` commands.

### Validation
I have cloned the repo locally and compiled a binary with the changes using bun.  With the updated binary I have confirmed that remote urls with and without the `.git` suffix are now supported.