### PR TITLE
Fix master-base detection during sync

### DIFF
--- a/src/app/SyncGithub.test.ts
+++ b/src/app/SyncGithub.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+
+import type { CommitMetadataGroup } from "./SyncGithub";
+import { _is_master_base } from "./SyncGithub";
+
+function buildGroup(overrides: Partial<CommitMetadataGroup> = {}): CommitMetadataGroup {
+  return {
+    id: "group-1",
+    title: "title",
+    master_base: false,
+    base: "feature/base",
+    dirty: false,
+    commits: [],
+    pr: {
+      id: "pr-id",
+      number: 1,
+      state: "OPEN",
+      baseRefName: "master",
+      headRefName: "group-1",
+      commits: [] as any,
+      title: "t",
+      body: "",
+      url: "https://example.com/pr/1",
+      isDraft: false,
+    },
+    ...overrides,
+  } as CommitMetadataGroup;
+}
+
+test("treats master_base flag as master", () => {
+  const group = buildGroup({ master_base: true, base: "feature/base" });
+
+  const result = _is_master_base({ group, master_branch: "origin/master" });
+
+  expect(result).toBe(true);
+});
+
+test("treats group base matching master as master", () => {
+  const group = buildGroup({ base: "origin/master", master_base: false });
+
+  const result = _is_master_base({ group, master_branch: "origin/master" });
+
+  expect(result).toBe(true);
+});
+
+test("ignores pr base when group base differs", () => {
+  const group = buildGroup({ base: "feature/base", master_base: false });
+
+  const result = _is_master_base({ group, master_branch: "origin/master" });
+
+  expect(result).toBe(false);
+});


### PR DESCRIPTION
- ensure sync treats a group as master-based using the intended base (commit metadata) rather than the PR’s current base, so top-of-stack PRs get updated correctly
- factor master-base check into a helper for reuse and add unit tests