### PR TITLE
Abort cherry-pick when resetting during rebase command

### DIFF
--- a/src/app/ManualRebase.tsx
+++ b/src/app/ManualRebase.tsx
@@ -147,6 +147,7 @@ async function run() {
     // always hard reset and clean to allow subsequent checkout
     // if there are files checkout will fail and cascade fail subsequent commands
     cli.sync(`git reset --hard`, spawn_options);
+    cli.sync(`git cherry-pick --abort`, spawn_options);
     cli.sync(`git clean -fd`, spawn_options);
 
     // always put self back in original branch

--- a/src/commands/Rebase.tsx
+++ b/src/commands/Rebase.tsx
@@ -184,6 +184,7 @@ Rebase.run = async function run(props: Props) {
     // always hard reset and clean to allow subsequent checkout
     // if there are files checkout will fail and cascade fail subsequent commands
     cli.sync(`git reset --hard`, spawn_options);
+    cli.sync(`git cherry-pick --abort`, spawn_options);
     cli.sync(`git clean -fd`, spawn_options);
 
     // always put self back in original branch


### PR DESCRIPTION
A couple time after a failed `git stack rebase` due to conflicts, I've seen the next command notify me that a cherry-pick is still in progress. Fix this by aborting cherry-pick when rebase resets the branch to the previous state.