### PR TITLE
Run pre-push verification before syncing stack

### DIFF
--- a/src/app/SyncGithub.tsx
+++ b/src/app/SyncGithub.tsx
@@ -4,7 +4,12 @@ import * as Ink from "ink-cjs";
 import last from "lodash/last";
 
 import { Await } from "~/app/Await";
+import { Command } from "~/app/Command";
+import { FormatText } from "~/app/FormatText";
+import { Parens } from "~/app/Parens";
 import { Store } from "~/app/Store";
+import { YesNoPrompt } from "~/app/YesNoPrompt";
+import * as CommitMetadata from "~/core/CommitMetadata";
 import * as StackSummaryTable from "~/core/StackSummaryTable";
 import { cli } from "~/core/cli";
 import { colors } from "~/core/colors";
@@ -13,13 +18,35 @@ import * as github from "~/core/github";
 import { invariant } from "~/core/invariant";
 import { sleep } from "~/core/sleep";
 
-import type * as CommitMetadata from "~/core/CommitMetadata";
-
 export function SyncGithub() {
-  return <Await fallback={<Ink.Text color={colors.yellow}>Syncing…</Ink.Text>} function={run} />;
+  const [fold_prompt, set_fold_prompt] = React.useState<null | FoldPromptState>(null);
+
+  const ask_fold = React.useCallback((args: FoldPromptArgs) => {
+    return new Promise<boolean>((resolve) => {
+      set_fold_prompt({ ...args, resolve });
+    });
+  }, []);
+
+  const run_sync = React.useCallback(() => run({ ask_fold }), [ask_fold]);
+
+  return (
+    <React.Fragment>
+      <Await fallback={<Ink.Text color={colors.yellow}>Syncing…</Ink.Text>} function={run_sync} />
+
+      {!fold_prompt ? null : (
+        <FoldPrompt
+          state={fold_prompt}
+          onAnswer={(answer) => {
+            fold_prompt.resolve(answer);
+            set_fold_prompt(null);
+          }}
+        />
+      )}
+    </React.Fragment>
+  );
 }
 
-async function run() {
+async function run(run_args: { ask_fold: AskFold }) {
   const state = Store.getState();
   const actions = state.actions;
   const argv = state.argv;
@@ -35,14 +62,14 @@ async function run() {
   invariant(repo_path, "repo_path must exist");
   invariant(sync_github, "sync_github must exist");
 
-  const commit_range = sync_github.commit_range;
+  let commit_range = sync_github.commit_range;
 
   let DEFAULT_PR_BODY = "";
   if (state.pr_template_body) {
     DEFAULT_PR_BODY = state.pr_template_body;
   }
 
-  const push_group_list = get_push_group_list();
+  let push_group_list = get_push_group_list();
 
   // for all push targets in push_group_list
   // things that can be done in parallel are grouped by numbers
@@ -53,10 +80,18 @@ async function run() {
   // 2 create PR / edit PR
   // --------------------------------------
 
-  function create_git_push_command(base: string, target: string) {
+  function create_git_push_command(
+    base: string,
+    target: string,
+    options: { dry_run?: boolean; no_verify?: boolean } = {},
+  ) {
     const command = [`${base} push -f origin`];
 
-    if (argv.verify === false) {
+    if (options.dry_run) {
+      command.push("--dry-run");
+    }
+
+    if (options.no_verify || argv.verify === false) {
       command.push("--no-verify");
     }
 
@@ -65,52 +100,7 @@ async function run() {
   }
 
   try {
-    const before_push_tasks = [];
-    for (const group of push_group_list) {
-      before_push_tasks.push(before_push({ group }));
-    }
-
-    await Promise.all(before_push_tasks);
-
-    const git_push_target_list: Array<string> = [];
-
-    for (let i = 0; i < push_group_list.length; i++) {
-      const group = push_group_list[i];
-      const last_commit = last(group.commits);
-      invariant(last_commit, "last_commit must exist");
-
-      // push group in isolation if master_base is set
-      if (group.master_base) {
-        await push_master_group(group);
-        continue;
-      }
-
-      // explicit refs/heads head branch to avoid push failing
-      //
-      //   ❯ git push -f origin --no-verify f6e249051b4820a03deb957ddebc19acfd7dfd7c:gs-ED2etrzv2
-      //   error: The destination you provided is not a full refname (i.e.,
-      //   starting with "refs/"). We tried to guess what you meant by:
-      //
-      //   - Looking for a ref that matches 'gs-ED2etrzv2' on the remote side.
-      //   - Checking if the <src> being pushed ('f6e249051b4820a03deb957ddebc19acfd7dfd7c')
-      //     is a ref in "refs/{heads,tags}/". If so we add a corresponding
-      //     refs/{heads,tags}/ prefix on the remote side.
-      //
-      //   Neither worked, so we gave up. You must fully qualify the ref.
-      //   hint: The <src> part of the refspec is a commit object.
-      //   hint: Did you mean to create a new branch by pushing to
-      //   hint: 'f6e249051b4820a03deb957ddebc19acfd7dfd7c:refs/heads/gs-ED2etrzv2'?
-      //   error: failed to push some refs to 'github.com:magus/git-multi-diff-playground.git'
-      //
-      const target = `${last_commit.sha}:refs/heads/${group.id}`;
-      git_push_target_list.push(target);
-    }
-
-    if (git_push_target_list.length > 0) {
-      const push_target = git_push_target_list.join(" ");
-      const git_push_command = create_git_push_command("git", push_target);
-      await cli(git_push_command);
-    }
+    await push_groups();
 
     const pr_url_by_group_id: Record<string, string> = {};
 
@@ -202,6 +192,213 @@ async function run() {
     return push_group_list;
   }
 
+  async function refresh_commit_range() {
+    commit_range = await CommitMetadata.range(commit_map ?? undefined);
+    push_group_list = get_push_group_list();
+
+    actions.set((state) => {
+      state.sync_github = { commit_range };
+    });
+  }
+
+  async function push_groups() {
+    if (argv.verify === false) {
+      await push_groups_batched_no_verify();
+      return;
+    }
+
+    let should_retry_validation = true;
+    while (should_retry_validation) {
+      const result = await verify_stack_tip_push();
+      if (result === "retry") {
+        await refresh_commit_range();
+        continue;
+      }
+
+      should_retry_validation = false;
+    }
+
+    await push_groups_batched_no_verify();
+  }
+
+  async function push_groups_batched_no_verify() {
+    const before_push_tasks = [];
+    for (const group of push_group_list) {
+      before_push_tasks.push(before_push({ group }));
+    }
+
+    await Promise.all(before_push_tasks);
+
+    try {
+      const git_push_target_list: Array<string> = [];
+
+      for (const group of push_group_list) {
+        const last_commit = last(group.commits);
+        invariant(last_commit, "last_commit must exist");
+
+        // push group in isolation if master_base is set
+        if (group.master_base) {
+          await push_master_group(group, { no_verify: true });
+          continue;
+        }
+
+        git_push_target_list.push(get_push_target({ group, last_commit }));
+      }
+
+      if (git_push_target_list.length > 0) {
+        const push_target = git_push_target_list.join(" ");
+        const git_push_command = create_git_push_command("git", push_target, {
+          no_verify: true,
+        });
+        await cli(git_push_command);
+      }
+    } catch (err) {
+      await restore_pr_bases_after_push(push_group_list);
+      throw err;
+    }
+  }
+
+  async function verify_stack_tip_push(): Promise<"done" | "retry"> {
+    const group = get_stack_tip_group();
+    const last_commit = last(group.commits);
+    invariant(last_commit, "last_commit must exist");
+
+    let push_error: unknown;
+    let should_retry = false;
+    const before_status = await get_worktree_status();
+
+    try {
+      const git_push_command = create_git_push_command("git", `HEAD:refs/heads/${group.id}`, {
+        dry_run: true,
+      });
+      await cli(git_push_command);
+    } catch (err) {
+      push_error = err;
+
+      should_retry = await handle_failed_verified_push({
+        before_status,
+        group,
+        last_commit,
+      });
+    }
+
+    if (should_retry) {
+      return "retry";
+    }
+
+    if (push_error) {
+      throw push_error;
+    }
+
+    return "done";
+  }
+
+  function get_stack_tip_group() {
+    const head_commit = last(commit_range.commit_list);
+    invariant(head_commit, "head_commit must exist");
+
+    const head_group_id = commit_map?.[head_commit.sha]?.id ?? head_commit.branch_id;
+    const group = commit_range.group_list.find((group) => group.id === head_group_id);
+    if (group && group.id !== commit_range.UNASSIGNED) {
+      return group;
+    }
+
+    throw new Error("Unable to find stack tip group");
+  }
+
+  function get_push_target(args: { group: CommitMetadataGroup; last_commit: git.Commit }) {
+    const { group, last_commit } = args;
+
+    // explicit refs/heads head branch to avoid push failing
+    //
+    //   ❯ git push -f origin --no-verify f6e249051b4820a03deb957ddebc19acfd7dfd7c:gs-ED2etrzv2
+    //   error: The destination you provided is not a full refname (i.e.,
+    //   starting with "refs/"). We tried to guess what you meant by:
+    //
+    //   - Looking for a ref that matches 'gs-ED2etrzv2' on the remote side.
+    //   - Checking if the <src> being pushed ('f6e249051b4820a03deb957ddebc19acfd7dfd7c')
+    //     is a ref in "refs/{heads,tags}/". If so we add a corresponding
+    //     refs/{heads,tags}/ prefix on the remote side.
+    //
+    //   Neither worked, so we gave up. You must fully qualify the ref.
+    //   hint: The <src> part of the refspec is a commit object.
+    //   hint: Did you mean to create a new branch by pushing to
+    //   hint: 'f6e249051b4820a03deb957ddebc19acfd7dfd7c:refs/heads/gs-ED2etrzv2'?
+    //   error: failed to push some refs to 'github.com:magus/git-multi-diff-playground.git'
+    //
+    return `${last_commit.sha}:refs/heads/${group.id}`;
+  }
+
+  async function get_worktree_status() {
+    return (await cli("git status --porcelain", { quiet: true })).stdout;
+  }
+
+  async function handle_failed_verified_push(args: {
+    before_status: string;
+    group: CommitMetadataGroup;
+    last_commit: git.Commit;
+  }) {
+    const { before_status, group, last_commit } = args;
+
+    const after_status = await get_worktree_status();
+    if (before_status || !after_status) {
+      return false;
+    }
+
+    const diff_stat = (await cli("git --no-pager diff --stat --color=never", { quiet: true }))
+      .stdout;
+
+    let diff = "";
+    if (argv.verbose) {
+      diff = (await cli("git --no-pager diff --color=never", { quiet: true })).stdout;
+    }
+
+    const should_fold = await run_args.ask_fold({
+      commit_sha: last_commit.sha,
+      diff,
+      diff_stat,
+      group_id: group.id,
+      status: after_status,
+      subject: last_commit.subject_line,
+    });
+
+    if (!should_fold) {
+      return false;
+    }
+
+    await fold_worktree_changes_into_commit(last_commit.sha);
+    return true;
+  }
+
+  async function fold_worktree_changes_into_commit(commit_sha: string) {
+    actions.output(
+      <FormatText
+        wrapper={<Ink.Text color={colors.yellow} />}
+        message="Folding pre-push changes into {sha}…"
+        values={{
+          sha: <Parens>{commit_sha.slice(0, 12)}</Parens>,
+        }}
+      />,
+    );
+
+    await cli("git add -A");
+    await cli(`git commit --fixup ${commit_sha}`);
+
+    try {
+      await cli(`git rebase -i --autosquash ${commit_sha}^`, {
+        env: {
+          ...process.env,
+          GIT_EDITOR: "true",
+        },
+      });
+    } catch (err) {
+      actions.error("🚨 Autosquash hit conflicts while folding pre-push changes");
+      actions.error("Resolve the conflicts, run `git add ...`, then `git rebase --continue`.");
+      actions.error("Or run `git rebase --abort` to abandon the fold.");
+      throw err;
+    }
+  }
+
   async function before_push(args: { group: CommitMetadataGroup }) {
     const { group } = args;
 
@@ -243,18 +440,7 @@ async function run() {
     invariant(group.base, "group.base must exist");
 
     if (group.pr) {
-      // there are two scenarios where we should restore the base after push
-      // 1. if we aren't master base and pr is master base we should fix it
-      const base_mismatch = !group.master_base && is_pr_master_base(group);
-      // 2. if group pr was not master before the push we set it to master before pushing
-      //    now we need to restore it back to how it was before the before_push
-      const was_modified_before_push = !is_pr_master_base(group);
-
-      const needs_base_fix = base_mismatch || was_modified_before_push;
-      if (needs_base_fix) {
-        // ensure base matches pr in github
-        await github.pr_edit({ branch: group.id, base: group.base });
-      }
+      await restore_pr_base_after_push(group);
     } else {
       // create pr in github
       const pr_url = await github.pr_create({
@@ -273,6 +459,34 @@ async function run() {
       // update pr_url_by_group_id with created pr_url
       args.pr_url_by_group_id[group.id] = pr_url;
     }
+  }
+
+  async function restore_pr_base_after_push(group: CommitMetadataGroup) {
+    invariant(group.base, "group.base must exist");
+
+    // there are two scenarios where we should restore the base after push
+    // 1. if we aren't master base and pr is master base we should fix it
+    const base_mismatch = !group.master_base && is_pr_master_base(group);
+    // 2. if group pr was not master before the push we set it to master before pushing
+    //    now we need to restore it back to how it was before the before_push
+    const was_modified_before_push = !is_pr_master_base(group);
+
+    const needs_base_fix = base_mismatch || was_modified_before_push;
+    if (needs_base_fix) {
+      // ensure base matches pr in github
+      await github.pr_edit({ branch: group.id, base: group.base });
+    }
+  }
+
+  async function restore_pr_bases_after_push(group_list: Array<CommitMetadataGroup>) {
+    const tasks = [];
+    for (const group of group_list) {
+      if (group.pr) {
+        tasks.push(restore_pr_base_after_push(group));
+      }
+    }
+
+    await Promise.all(tasks);
   }
 
   async function update_pr(args: {
@@ -329,17 +543,99 @@ async function run() {
     return `origin/${group.pr.baseRefName}` === master_branch;
   }
 
-  async function push_master_group(group: CommitMetadataGroup) {
+  async function push_master_group(
+    group: CommitMetadataGroup,
+    options: { dry_run?: boolean; no_verify?: boolean } = {},
+  ) {
     invariant(repo_path, "repo_path must exist");
 
     const commit_list = group.commits;
     const { worktree_path } = await git.worktree_add({ commit_list });
 
     const push_target = `HEAD:refs/heads/${group.id}`;
-    const git_push_command = create_git_push_command(`git -C ${worktree_path}`, push_target);
+    const git_push_command = create_git_push_command(
+      `git -C ${worktree_path}`,
+      push_target,
+      options,
+    );
 
     await cli(git_push_command);
   }
 }
 
 type CommitMetadataGroup = CommitMetadata.CommitRange["group_list"][number];
+
+type AskFold = (args: FoldPromptArgs) => Promise<boolean>;
+
+type FoldPromptArgs = {
+  commit_sha: string;
+  diff: string;
+  diff_stat: string;
+  group_id: string;
+  status: string;
+  subject: string;
+};
+
+type FoldPromptState = FoldPromptArgs & {
+  resolve: (answer: boolean) => void;
+};
+
+function FoldPrompt(props: { state: FoldPromptState; onAnswer: (answer: boolean) => void }) {
+  const { state } = props;
+
+  return (
+    <Ink.Box flexDirection="column">
+      <Ink.Box height={1} />
+      <FormatText
+        wrapper={<Ink.Text color={colors.yellow} />}
+        message="Pre-push modified files while verifying {group}."
+        values={{
+          group: <Command>{state.group_id}</Command>,
+        }}
+      />
+      <FormatText
+        wrapper={<Ink.Text color={colors.gray} />}
+        message="Target commit: {subject} {sha}"
+        values={{
+          sha: <Parens>{state.commit_sha.slice(0, 12)}</Parens>,
+          subject: <Ink.Text color={colors.white}>{state.subject}</Ink.Text>,
+        }}
+      />
+
+      <Ink.Box height={1} />
+      <Ink.Text color={colors.gray}>git status --short</Ink.Text>
+      <Ink.Text>{state.status}</Ink.Text>
+
+      {state.diff_stat ? (
+        <React.Fragment>
+          <Ink.Box height={1} />
+          <Ink.Text color={colors.gray}>git diff --stat</Ink.Text>
+          <Ink.Text>{state.diff_stat}</Ink.Text>
+        </React.Fragment>
+      ) : null}
+
+      {state.diff ? (
+        <React.Fragment>
+          <Ink.Box height={1} />
+          <Ink.Text color={colors.gray}>git diff</Ink.Text>
+          <Ink.Text>{state.diff}</Ink.Text>
+        </React.Fragment>
+      ) : null}
+
+      {!state.diff ? (
+        <Ink.Text color={colors.gray}>Run with --verbose to show the full diff here.</Ink.Text>
+      ) : null}
+
+      <YesNoPrompt
+        message={
+          <FormatText
+            wrapper={<Ink.Text color={colors.yellow} />}
+            message="Fold these changes into the target commit and retry?"
+          />
+        }
+        onYes={() => props.onAnswer(true)}
+        onNo={() => props.onAnswer(false)}
+      />
+    </Ink.Box>
+  );
+}


### PR DESCRIPTION
## Summary

Run pre-push verification in a shape that normal pre-push hooks can actually validate before syncing a stack.

Previously, `git stack` could pass `--verify`, but the sync push used a batched multi-ref push for the whole stack. Some pre-push hook setups intentionally skip or cannot fully validate that kind of push, so stack syncs could succeed without running the same checks that a normal single-branch `git push` would run.

This change adds a single-ref dry-run push of the stack tip before syncing. Once that verification passes, `git stack` keeps the existing fast batched push behavior and skips re-running hooks for the actual push.

## Details

- Runs a verified dry-run push for `HEAD` to the stack-tip branch before syncing.
- Preserves `git stack --no-verify` by skipping the verification pass and pushing with `--no-verify`.
- Uses the existing batched refspec push path after verification succeeds, with `--no-verify` to avoid duplicate hook runs.
- If a pre-push hook modifies a clean worktree, prompts to fold those changes into the target commit and retry verification.
- Restores PR base branches if a push fails after temporary base edits.

## Test plan

- `prettier --check src/app/SyncGithub.tsx`
- `./node_modules/.bin/eslint src/app/SyncGithub.tsx`
- `./node_modules/.bin/tsc`
- `./node_modules/.bin/bun test`
